### PR TITLE
Adjust asset URLs in SGPJ views

### DIFF
--- a/resources/views/sgpj-detalhe.blade.php
+++ b/resources/views/sgpj-detalhe.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Detalhes do Processo</title>
+    <link rel="stylesheet" href="{{ asset('styles.css') }}" />
+  </head>
+  <body>
+    <main id="detalhe"></main>
+
+    <nav>
+      <a href="{{ route('processos.index') }}">&larr; Voltar</a>
+    </nav>
+
+    <script>
+      window.sgpjDetalhesConfig = {
+        processosJsonUrl: "{{ asset('processos.json') }}"
+      };
+    </script>
+    <script src="{{ asset('detalhes.js') }}" defer></script>
+  </body>
+</html>

--- a/resources/views/sgpj.blade.php
+++ b/resources/views/sgpj.blade.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SGPJ</title>
+    <link rel="stylesheet" href="{{ asset('styles.css') }}" />
+  </head>
+  <body>
+    <div id="app"></div>
+
+    <script>
+      window.sgpjConfig = {
+        processosJsonUrl: "{{ asset('processos.json') }}",
+        processoDetalheUrlTemplate: "{{ route('processos.show', ['id' => '__ID__']) }}"
+      };
+    </script>
+    <script src="{{ asset('script.js') }}" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the SGPJ overview view's hard-coded asset paths with Laravel `asset()` and `route()` helpers
- update the detail view to use helper-generated URLs for styles, data, scripts, and the back link

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc715534b4832bafb25f67dbdf0f1c